### PR TITLE
fix(all): resolve 12 rendering, wrapping, and color bugs

### DIFF
--- a/box.go
+++ b/box.go
@@ -510,8 +510,15 @@ func (b *Box) Render(title, content string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// Wrapping (and user-supplied newlines) can split an SGR span or an OSC 8
+	// hyperlink across lines, but every row is assembled independently with
+	// border glyphs and padding around it; isolate per-line state so open
+	// styles never bleed into the chrome. Must run after wrapping, which is
+	// what creates the new line boundaries.
+	content = isolateLineStyles(content)
 
 	title = expandTabs(title)
+	title = isolateLineStyles(title)
 	title, err = applyColor(title, b.titleColor)
 	if err != nil {
 		return "", err

--- a/box.go
+++ b/box.go
@@ -51,6 +51,7 @@ type config struct {
 	color         string        // ANSI color (or hex code) for the box chrome.
 	allowWrapping bool          // Whether long content may wrap.
 	wrappingLimit int           // Custom wrap width when wrapping is enabled.
+	wrapLimitSet  bool          // Tracks if WrapLimit was called, so 0 can be rejected.
 	styleSet      bool          // Tracks if a style preset has already been applied.
 }
 
@@ -181,6 +182,10 @@ func (b *Box) Vertical(glyph string) *Box {
 // box.BrightRed) or a #RGB / #RRGGBB / rgb:RRRR/GGGG/BBBB /
 // rgba:RRRR/GGGG/BBBB/AAAA value.
 //
+// Colors are automatically converted to the terminal's detected color
+// profile, and suppressed entirely when the output does not support color
+// (NO_COLOR set, TERM=dumb, or a non-TTY stdout).
+//
 // Invalid colors cause Render to return an error.
 func (b *Box) TitleColor(color string) *Box {
 	b.titleColor = color
@@ -193,6 +198,10 @@ func (b *Box) TitleColor(color string) *Box {
 // box.BrightRed) or a #RGB / #RRGGBB / rgb:RRRR/GGGG/BBBB /
 // rgba:RRRR/GGGG/BBBB/AAAA value.
 //
+// Colors are automatically converted to the terminal's detected color
+// profile, and suppressed entirely when the output does not support color
+// (NO_COLOR set, TERM=dumb, or a non-TTY stdout).
+//
 // Invalid colors cause Render to return an error.
 func (b *Box) ContentColor(color string) *Box {
 	b.contentColor = color
@@ -204,6 +213,10 @@ func (b *Box) ContentColor(color string) *Box {
 // Accepts one of the first 16 ANSI color name constants (e.g. box.Green,
 // box.BrightRed) or a #RGB / #RRGGBB / rgb:RRRR/GGGG/BBBB /
 // rgba:RRRR/GGGG/BBBB/AAAA value.
+//
+// Colors are automatically converted to the terminal's detected color
+// profile, and suppressed entirely when the output does not support color
+// (NO_COLOR set, TERM=dumb, or a non-TTY stdout).
 //
 // Invalid colors cause Render to return an error.
 func (b *Box) Color(color string) *Box {
@@ -232,9 +245,13 @@ func (b *Box) WrapContent(allow bool) *Box {
 }
 
 // WrapLimit enables wrapping and sets an explicit maximum width for content.
+//
+// The limit must be positive; Render returns an error otherwise. For
+// automatic wrapping based on the terminal width, use WrapContent instead.
 func (b *Box) WrapLimit(limit int) *Box {
 	b.allowWrapping = true
 	b.wrappingLimit = limit
+	b.wrapLimitSet = true
 	return b
 }
 
@@ -274,12 +291,12 @@ func (b *Box) wrapContent(content string) (string, error) {
 	if !b.allowWrapping {
 		return content, nil
 	}
-	if b.wrappingLimit < 0 {
-		return "", fmt.Errorf("wrapping limit cannot be negative")
+	if b.wrapLimitSet && b.wrappingLimit <= 0 {
+		return "", fmt.Errorf("wrap limit must be positive; use WrapContent(true) for automatic terminal-based wrapping")
 	}
 	// If limit not provided then use 2*TermWidth/3 as limit else
 	// use the one provided
-	if b.wrappingLimit != 0 {
+	if b.wrappingLimit > 0 {
 		return ansi.Wrap(content, b.wrappingLimit, ""), nil
 	}
 	if !isTTY(os.Stdout.Fd()) {
@@ -318,7 +335,7 @@ func (b *Box) prepareContentLines(title, content string) ([]string, int, error) 
 	var contentLines []string
 	if title != "" {
 		if titlePos != Inside && strings.Contains(title, "\n") {
-			return nil, 0, fmt.Errorf("multiline titles are only supported Inside title position only")
+			return nil, 0, fmt.Errorf("multiline titles are only supported with the Inside title position")
 		}
 		if titlePos == Inside {
 			contentLines = append(contentLines, strings.Split(title, "\n")...)
@@ -351,10 +368,21 @@ func (b *Box) computeLayout(contentLines []string, title string) boxLayout {
 	contentInnerWidth := longest + 2*b.px
 	innerWidth := contentInnerWidth
 
+	verticalWidth := charWidth(b.vertical)
+	horizontalWidth := charWidth(b.horizontal)
+
 	// Make sure the box is wide enough to fit the title when it's on Top/Bottom.
+	// The titled bar's span between its corners is
+	// innerWidth + 2*verticalWidth - leftW - rightW, so when the corner glyphs
+	// are wider than the vertical glyph the inner width must grow by the
+	// difference or the titled bar overflows the box.
 	if (b.titlePos == Top || b.titlePos == Bottom) && title != "" {
+		left, right := b.topLeft, b.topRight
+		if b.titlePos == Bottom {
+			left, right = b.bottomLeft, b.bottomRight
+		}
 		titleWidth := runewidth.StringWidth(ansi.Strip(title))
-		if minW := titleWidth + 2; minW > innerWidth {
+		if minW := titleWidth + 2 + charWidth(left) + charWidth(right) - 2*verticalWidth; minW > innerWidth {
 			innerWidth = minW
 		}
 	}
@@ -363,9 +391,6 @@ func (b *Box) computeLayout(contentLines []string, title string) boxLayout {
 	if innerWidth > contentInnerWidth {
 		longest = max(innerWidth-2*b.px, 0)
 	}
-
-	verticalWidth := charWidth(b.vertical)
-	horizontalWidth := charWidth(b.horizontal)
 
 	// Ensure the inner width is a multiple of the horizontal glyph width so
 	// the bar is visually uniform.
@@ -426,12 +451,39 @@ func (b *Box) buildAndColorBars(title string, lay boxLayout) (string, string, er
 	return topBar, bottomBar, nil
 }
 
+// normalizeGlyphs replaces border glyphs with zero visible width (empty
+// strings, zero-width characters, or ANSI-only strings) with a single space,
+// matching the Hidden style's idiom for an invisible border. Such glyphs
+// cannot form a border: the layout math counts them via charWidth's width-1
+// fallback while they render zero columns, producing ragged boxes.
+//
+// The replacement happens on a shallow copy so Render never mutates the
+// receiver; when every glyph is visible the receiver is returned unchanged.
+func (b *Box) normalizeGlyphs() *Box {
+	clone := *b
+	changed := false
+	for _, g := range []*string{
+		&clone.topLeft, &clone.topRight,
+		&clone.bottomLeft, &clone.bottomRight,
+		&clone.horizontal, &clone.vertical,
+	} {
+		if runewidth.StringWidth(ansi.Strip(*g)) == 0 {
+			*g = " "
+			changed = true
+		}
+	}
+	if !changed {
+		return b
+	}
+	return &clone
+}
+
 // Render generates the box with the given title and content.
 //
 // It returns an error if:
 //   - the BoxStyle is invalid,
 //   - the TitlePosition is invalid,
-//   - the wrapping limit is negative,
+//   - the wrap limit set by WrapLimit is not positive,
 //   - padding is negative,
 //   - a multiline title is used with a non-Inside TitlePosition, or
 //   - any configured colors are invalid.
@@ -444,7 +496,16 @@ func (b *Box) Render(title, content string) (string, error) {
 	if b.mx < 0 || b.my < 0 {
 		return "", fmt.Errorf("margin cannot be negative")
 	}
+	b = b.normalizeGlyphs()
 
+	// Normalize Windows line endings: a raw \r survives width calculations
+	// but makes the terminal carriage-return mid-line, corrupting the box.
+	title = strings.ReplaceAll(title, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+
+	// Tabs must be expanded before wrapping: ansi.Wrap counts a tab as a
+	// single cell, so wrapping first would let expanded lines exceed the limit.
+	content = expandTabs(content)
 	content, err := b.wrapContent(content)
 	if err != nil {
 		return "", err
@@ -455,7 +516,6 @@ func (b *Box) Render(title, content string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	content = expandTabs(content)
 	content, err = applyColor(content, b.contentColor)
 	if err != nil {
 		return "", err

--- a/box_render_test.go
+++ b/box_render_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
@@ -1512,6 +1513,50 @@ func TestRenderContentColorBlankLineNoEscapes(t *testing.T) {
 	rows := strings.Split(out, "\n")
 	if strings.Contains(rows[2], "\x1b") {
 		t.Errorf("blank content row carries escape sequences: %q", rows[2])
+	}
+}
+
+// TestRenderStyledGlyphTitledBarOffset pins the titled-bar offset fix: border
+// glyphs may carry their own ANSI styling, so the title offset returned by
+// buildTitledBar must be counted in ANSI-stripped bytes. Counting raw bytes
+// shifted applyColorBar's slice points past the title and into the middle of
+// a multi-byte fill rune, producing a duplicated title, a stray partial-rune
+// byte (invalid UTF-8), and a bar wider than the box.
+func TestRenderStyledGlyphTitledBarOffset(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func() *Box
+	}{
+		{"styled corner, Top title", func() *Box {
+			return NewBox().TopLeft("\x1b[31m+\x1b[0m").TitlePosition(Top)
+		}},
+		{"styled corner, Bottom title", func() *Box {
+			return NewBox().BottomLeft("\x1b[31m+\x1b[0m").TitlePosition(Bottom)
+		}},
+		{"styled fill, Top title aligned Right", func() *Box {
+			return NewBox().Horizontal("\x1b[35m-\x1b[0m").TitlePosition(Top).TitleAlign(Right)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := tc.setup().Color(Green).TitleColor(Red)
+			out, err := b.Render("TITLE", "hello world")
+			if err != nil {
+				t.Fatalf("Render returned error: %v", err)
+			}
+			if !utf8.ValidString(out) {
+				t.Fatalf("output is not valid UTF-8: %q", out)
+			}
+			rows := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+			for i, row := range rows {
+				if got, want := runewidth.StringWidth(ansi.Strip(row)), runewidth.StringWidth(ansi.Strip(rows[0])); got != want {
+					t.Errorf("row %d visible width %d, want %d: %q", i, got, want, row)
+				}
+			}
+			if got := strings.Count(ansi.Strip(out), "TITLE"); got != 1 {
+				t.Errorf("title appears %d times in output, want 1: %q", got, out)
+			}
+		})
 	}
 }
 

--- a/box_render_test.go
+++ b/box_render_test.go
@@ -498,18 +498,34 @@ func TestRenderMultilineTitleNonInside(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error for multiline title at non-Inside position, got nil")
 	}
-	if !strings.Contains(err.Error(), "multiline titles are only supported Inside title position only") {
+	if !strings.Contains(err.Error(), "multiline titles are only supported with the Inside title position") {
 		t.Errorf("unexpected error message: %v", err)
 	}
 }
 
-func TestRenderNegativeWrapLimit(t *testing.T) {
-	b := NewBox().Padding(1, 1).Style(Single).WrapContent(true).WrapLimit(-1)
+func TestRenderNonPositiveWrapLimit(t *testing.T) {
+	// WrapLimit(0) used to silently fall through to terminal-width detection
+	// and, on a non-TTY, fail by advising the caller to use WrapLimit.
+	// Zero and negative limits now error explicitly.
+	for _, limit := range []int{-1, 0} {
+		b := NewBox().Padding(1, 1).Style(Single).WrapLimit(limit)
+		if _, err := b.Render("Title", "Content"); err == nil {
+			t.Fatalf("expected error for WrapLimit(%d), got nil", limit)
+		} else if !strings.Contains(err.Error(), "wrap limit must be positive") {
+			t.Errorf("unexpected error message for WrapLimit(%d): %v", limit, err)
+		}
+	}
 
-	if _, err := b.Render("Title", "Content"); err == nil {
-		t.Fatalf("expected error for negative wrap limit, got nil")
-	} else if !strings.Contains(err.Error(), "wrapping limit cannot be negative") {
-		t.Errorf("unexpected error message for negative wrap limit: %v", err)
+	// The automatic path (WrapContent without WrapLimit) must be unaffected.
+	oldIsTTY, oldGetTermSize := isTTY, getTermSize
+	defer func() {
+		isTTY = oldIsTTY
+		getTermSize = oldGetTermSize
+	}()
+	isTTY = func(fd uintptr) bool { return true }
+	getTermSize = func(fd uintptr) (int, int, error) { return 80, 24, nil }
+	if _, err := NewBox().Style(Single).WrapContent(true).Render("Title", "Content"); err != nil {
+		t.Fatalf("WrapContent(true) auto mode should not error: %v", err)
 	}
 }
 
@@ -653,6 +669,27 @@ func TestRenderWithWrapLimit(t *testing.T) {
 	}
 }
 
+// TestRenderWrapLimitWithTabs guards against wrapping running before tab
+// expansion: ansi.Wrap counts a tab as one cell, so a tab expanding to up to
+// 8 spaces afterwards pushed the content area past the configured limit.
+func TestRenderWrapLimitWithTabs(t *testing.T) {
+	const limit = 10
+	b := NewBox().Style(Single).Padding(0, 0)
+	b.WrapLimit(limit)
+
+	out, err := b.Render("", "aa\tbb cc dd ee ff")
+	if err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+		// Inner content width = visible line width minus the two border cells.
+		if inner := runewidth.StringWidth(ansi.Strip(line)) - 2; inner > limit {
+			t.Errorf("content width %d exceeds WrapLimit(%d): %q", inner, limit, ansi.Strip(line))
+		}
+	}
+}
+
 func TestRenderWithVariousColorFormats(t *testing.T) {
 	title := "Color Formats"
 	content := "content"
@@ -788,6 +825,194 @@ func TestRenderEmojiBordersHaveConsistentWidth(t *testing.T) {
 
 	if topW != interiorW || interiorW != bottomW {
 		t.Fatalf("expected equal visual widths for emoji box borders, got top=%d interior=%d bottom=%d", topW, interiorW, bottomW)
+	}
+}
+
+// TestRenderEmptyTitleWithTitleColor guards against applyColor turning an
+// empty title into a non-empty ANSI-only string ("\x1b[38;…m\x1b[m"), which
+// made every title != "" check downstream render a phantom title: a gap in
+// the Top/Bottom bar, or a spurious title line plus separator Inside.
+func TestRenderEmptyTitleWithTitleColor(t *testing.T) {
+	for _, pos := range []TitlePosition{Inside, Top, Bottom} {
+		t.Run(string(pos), func(t *testing.T) {
+			plain, err := NewBox().Style(Single).TitlePosition(pos).Color(Cyan).Render("", "content here")
+			if err != nil {
+				t.Fatalf("Render error: %v", err)
+			}
+			colored, err := NewBox().Style(Single).TitlePosition(pos).Color(Cyan).TitleColor(Red).Render("", "content here")
+			if err != nil {
+				t.Fatalf("Render error: %v", err)
+			}
+			if plain != colored {
+				t.Errorf("TitleColor with empty title must be a no-op:\nwithout: %q\nwith:    %q", plain, colored)
+			}
+		})
+	}
+
+	// Same for empty content with ContentColor.
+	plain, err := NewBox().Style(Single).Render("Title", "")
+	if err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	colored, err := NewBox().Style(Single).ContentColor(Green).Render("Title", "")
+	if err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	if plain != colored {
+		t.Errorf("ContentColor with empty content must be a no-op:\nwithout: %q\nwith:    %q", plain, colored)
+	}
+
+	// Invalid colors must still error even when the title is empty.
+	if _, err := NewBox().Style(Single).TitleColor("NotAColor").Render("", "content"); err == nil {
+		t.Errorf("expected error for invalid TitleColor with empty title")
+	}
+}
+
+// TestRenderHyperlinkContentWithTabs guards against OSC-8 hyperlinks breaking
+// tab handling end to end: a raw \t used to leak through expandTabs into the
+// rendered box, where the terminal's own tab expansion breaks the border.
+func TestRenderHyperlinkContentWithTabs(t *testing.T) {
+	link := "\x1b]8;;https://example.com\x1b\\docs\x1b]8;;\x1b\\"
+	out, err := NewBox().Style(Single).Render("", link+"\tafter-tab\nplain line here padding")
+	if err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	if strings.Contains(out, "\t") {
+		t.Errorf("raw tab in rendered output: %q", out)
+	}
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	w0 := runewidth.StringWidth(ansi.Strip(lines[0]))
+	for i, line := range lines[1:] {
+		if w := runewidth.StringWidth(ansi.Strip(line)); w != w0 {
+			t.Errorf("line %d width %d != line 0 width %d:\n%s", i+1, w, w0, out)
+		}
+	}
+	// "docs" is 4 visible columns, so the tab should expand to 4 spaces.
+	if !strings.Contains(ansi.Strip(out), "docs    after-tab") {
+		t.Errorf("tab did not expand from the hyperlink's visible column:\n%q", ansi.Strip(out))
+	}
+}
+
+// TestRenderZeroWidthGlyphs guards against border glyphs with zero visible
+// width (empty strings, zero-width characters, ANSI-only strings) producing
+// ragged boxes: charWidth's width-1 fallback counted a column the glyph never
+// rendered. Render normalizes such glyphs to a single space.
+func TestRenderZeroWidthGlyphs(t *testing.T) {
+	cases := []struct {
+		name string
+		b    *Box
+	}{
+		{"empty-vertical", NewBox().Vertical("")},
+		{"empty-corners", NewBox().TopLeft("").TopRight("").BottomLeft("").BottomRight("")},
+		{"empty-horizontal", NewBox().Horizontal("")},
+		{"empty-top-corners-only", NewBox().TopLeft("").TopRight("")},
+		{"zero-width-space-vertical", NewBox().Vertical("\u200b")},
+		{"ansi-only-horizontal", NewBox().Horizontal("\x1b[31m\x1b[0m")},
+		{"zero-value-box", new(Box)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := tc.b.Render("Title", "some content")
+			if err != nil {
+				t.Fatalf("Render error: %v", err)
+			}
+			lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+			w0 := runewidth.StringWidth(ansi.Strip(lines[0]))
+			for i, line := range lines[1:] {
+				if w := runewidth.StringWidth(ansi.Strip(line)); w != w0 {
+					t.Errorf("line %d width %d != line 0 width %d:\n%s", i+1, w, w0, out)
+				}
+			}
+		})
+	}
+
+	// Semantic pin: an empty glyph renders identically to an explicit space.
+	emptyOut, err := NewBox().Vertical("").Render("T", "content")
+	if err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	spaceOut, err := NewBox().Vertical(" ").Render("T", "content")
+	if err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	if emptyOut != spaceOut {
+		t.Errorf("Vertical(\"\") and Vertical(\" \") render differently:\n%q\n%q", emptyOut, spaceOut)
+	}
+
+	// Normalization must not mutate the receiver.
+	b := NewBox().Vertical("")
+	if _, err := b.Render("T", "content"); err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	if b.vertical != "" {
+		t.Errorf("Render mutated the box's vertical glyph: %q", b.vertical)
+	}
+}
+
+// TestRenderCRLFContent guards against raw \r surviving into the output:
+// "line one\r" between the borders makes the terminal carriage-return
+// mid-line, so the right border overwrites the left edge.
+func TestRenderCRLFContent(t *testing.T) {
+	crlfOut, err := NewBox().Style(Single).Render("Ti\r\ntle", "line one\r\nline two")
+	if err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	if strings.Contains(crlfOut, "\r") {
+		t.Errorf("output contains raw \\r: %q", crlfOut)
+	}
+
+	// CRLF input must render identically to LF input.
+	lfOut, err := NewBox().Style(Single).Render("Ti\ntle", "line one\nline two")
+	if err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	if crlfOut != lfOut {
+		t.Errorf("CRLF and LF input render differently:\nCRLF: %q\nLF:   %q", crlfOut, lfOut)
+	}
+}
+
+// TestRenderWideCornersWithTitleBar guards against computeLayout sizing the box
+// from titleWidth+2 alone: the titled bar's span between its corners is
+// innerWidth + 2*verticalWidth - leftW - rightW, so corner glyphs wider than
+// the vertical glyph made the titled bar overflow the box whenever the title
+// dictated the box width.
+func TestRenderWideCornersWithTitleBar(t *testing.T) {
+	title := "A moderately long title here"
+	cases := []struct {
+		name   string
+		corner string
+		pos    TitlePosition
+	}{
+		{"emoji-corners-top", "🌸", Top},
+		{"emoji-corners-bottom", "🌸", Bottom},
+		{"ascii-wide-corners-top", "++", Top},
+		{"ascii-wide-corners-bottom", "++", Bottom},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := NewBox().Style(Single).TitlePosition(tc.pos).
+				TopLeft(tc.corner).TopRight(tc.corner).
+				BottomLeft(tc.corner).BottomRight(tc.corner)
+			// Short content so the title dictates the box width.
+			out, err := b.Render(title, "ab")
+			if err != nil {
+				t.Fatalf("Render error: %v", err)
+			}
+
+			lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+			w0 := runewidth.StringWidth(ansi.Strip(lines[0]))
+			for i, line := range lines[1:] {
+				if w := runewidth.StringWidth(ansi.Strip(line)); w != w0 {
+					t.Errorf("line %d width %d != line 0 width %d:\n%s", i+1, w, w0, out)
+				}
+			}
+			if !strings.Contains(out, title) {
+				t.Errorf("title missing from output:\n%s", out)
+			}
+		})
 	}
 }
 

--- a/box_render_test.go
+++ b/box_render_test.go
@@ -1371,3 +1371,164 @@ func titleStartColumn(line, title string) int {
 	}
 	return runewidth.StringWidth(before)
 }
+
+// assertRowsSelfContained fails if any row of a rendered box leaves ANSI
+// stream state open past its end: an SGR style without a trailing reset, or
+// an OSC 8 hyperlink opened but not closed on the same row. Open state would
+// style the following rows' borders and padding on a real terminal.
+func assertRowsSelfContained(t *testing.T, out string) {
+	t.Helper()
+	for i, row := range strings.Split(strings.TrimSuffix(out, "\n"), "\n") {
+		// Find the last SGR sequence in the row; if the row styles anything,
+		// it must end state-clean, i.e. the last SGR must be a reset.
+		lastSGR := ""
+		for s := row; ; {
+			idx := strings.Index(s, "\x1b[")
+			if idx == -1 {
+				break
+			}
+			s = s[idx:]
+			end := strings.IndexByte(s, 'm')
+			if end == -1 {
+				break
+			}
+			lastSGR = s[:end+1]
+			s = s[end+1:]
+		}
+		if lastSGR != "" && lastSGR != "\x1b[0m" && lastSGR != "\x1b[m" {
+			t.Errorf("row %d leaves SGR state open (last sequence %q): %q", i, lastSGR, row)
+		}
+
+		opens := strings.Count(row, "\x1b]8;")
+		closes := strings.Count(row, "\x1b]8;;\x1b\\") + strings.Count(row, "\x1b]8;;\a")
+		if opens != 2*closes {
+			t.Errorf("row %d leaves a hyperlink open (%d OSC 8 sequences, %d closes): %q", i, opens, closes, row)
+		}
+	}
+}
+
+// TestRenderWrappedColoredSpanKeepsBordersClean pins the fix for wrapping a
+// well-formed SGR span: ansi.Wrap does not re-arm styles across the lines it
+// creates, so without per-line isolation the span's color bled into the right
+// border of the first row and both borders of every following row.
+func TestRenderWrappedColoredSpanKeepsBordersClean(t *testing.T) {
+	b := NewBox().WrapLimit(12)
+	out, err := b.Render("", "\x1b[32mgreen green green green green\x1b[0m tail")
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+	assertRowsSelfContained(t, out)
+
+	rows := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+	want := []string{
+		"┌───────────┐",
+		"│\x1b[32mgreen green\x1b[0m│",
+		"│\x1b[32mgreen green\x1b[0m│",
+		"│\x1b[32mgreen\x1b[0m tail │",
+		"└───────────┘",
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("expected %d rows, got %d: %q", len(want), len(rows), out)
+	}
+	for i := range want {
+		if rows[i] != want[i] {
+			t.Errorf("row %d:\n got %q\nwant %q", i, rows[i], want[i])
+		}
+	}
+}
+
+// TestRenderMultilineSGRContentKeepsBordersClean covers a span crossing the
+// user's own newlines: the style is closed before each row's border and
+// re-armed on the next row, so the author's coloring is preserved without
+// touching padding or chrome.
+func TestRenderMultilineSGRContentKeepsBordersClean(t *testing.T) {
+	b := NewBox().Padding(2, 0)
+	out, err := b.Render("", "\x1b[31mred one\nred two\x1b[0m plain")
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+	assertRowsSelfContained(t, out)
+
+	rows := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+	if want := "│  \x1b[31mred one\x1b[0m        │"; rows[1] != want {
+		t.Errorf("row 1:\n got %q\nwant %q", rows[1], want)
+	}
+	if want := "│  \x1b[31mred two\x1b[0m plain  │"; rows[2] != want {
+		t.Errorf("row 2:\n got %q\nwant %q", rows[2], want)
+	}
+}
+
+// TestRenderWrappedHyperlinkKeepsBordersClean guards against box chrome
+// landing inside an OSC 8 hyperlink when the link text wraps: every row must
+// close the link before its right border and re-open it on the next row,
+// otherwise the borders and padding become clickable link targets.
+func TestRenderWrappedHyperlinkKeepsBordersClean(t *testing.T) {
+	link := "\x1b]8;;https://example.com\x1b\\click here for the documentation\x1b]8;;\x1b\\"
+	b := NewBox().WrapLimit(12)
+	out, err := b.Render("", link)
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+	assertRowsSelfContained(t, out)
+
+	rows := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+	for i, row := range rows[1 : len(rows)-1] {
+		if !strings.Contains(row, "\x1b]8;;https://example.com") {
+			t.Errorf("content row %d lost its hyperlink: %q", i+1, row)
+		}
+		if !strings.HasPrefix(row, "│") {
+			t.Errorf("content row %d: left border inside the hyperlink: %q", i+1, row)
+		}
+	}
+}
+
+// TestRenderTopTitleUnterminatedSGRClosed: an unterminated style in a
+// Top/Bottom title must be closed before the bar's fill continues, or the
+// rest of the bar (and every following row) inherits it.
+func TestRenderTopTitleUnterminatedSGRClosed(t *testing.T) {
+	b := NewBox().TitlePosition(Top)
+	out, err := b.Render("\x1b[31mRED", "content here")
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+	assertRowsSelfContained(t, out)
+
+	rows := strings.Split(out, "\n")
+	if want := "┌ \x1b[31mRED\x1b[0m ───────┐"; rows[0] != want {
+		t.Errorf("top bar:\n got %q\nwant %q", rows[0], want)
+	}
+}
+
+// TestRenderContentColorBlankLineNoEscapes: a blank content line has nothing
+// to style; coloring it produced an ANSI-only "styled empty string" row.
+func TestRenderContentColorBlankLineNoEscapes(t *testing.T) {
+	b := NewBox().ContentColor(Cyan)
+	out, err := b.Render("", "above\n\nbelow")
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+	assertRowsSelfContained(t, out)
+
+	rows := strings.Split(out, "\n")
+	if strings.Contains(rows[2], "\x1b") {
+		t.Errorf("blank content row carries escape sequences: %q", rows[2])
+	}
+}
+
+// TestRenderContentColorPreservesUserSpanAcrossLines: with ContentColor set,
+// each chrome segment ends in a reset; before per-line isolation that reset
+// silently truncated a user span at the first line boundary, so continuation
+// lines lost their color.
+func TestRenderContentColorPreservesUserSpanAcrossLines(t *testing.T) {
+	b := NewBox().ContentColor(Cyan)
+	out, err := b.Render("", "\x1b[31mred\nstill\x1b[0m plain")
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+	assertRowsSelfContained(t, out)
+
+	rows := strings.Split(out, "\n")
+	if !strings.Contains(rows[2], "\x1b[31mstill") {
+		t.Errorf("continuation row lost the user's spanning color: %q", rows[2])
+	}
+}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,184 @@
+package box
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
+)
+
+func FuzzIsolateLineStyles(f *testing.F) {
+	f.Add("\x1b[31mred\nline\x1b[0m")
+	f.Add("\x1b]8;;https://x.com\x1b\\a\nb\x1b]8;;\x1b\\")
+	f.Add("\x1b[1m\x1b[32m\nmix\x1b[m\n\n")
+	f.Add("plain\ntext")
+	f.Add("\x1b[38;5;10mx\n\x1b[0;31my")
+	f.Fuzz(func(t *testing.T, s string) {
+		out := isolateLineStyles(s) // must never panic or hang, even on garbage
+
+		// The content oracles below only hold for input that decodes cleanly:
+		// on malformed escapes (bare ESC, truncated CSI, unterminated OSC)
+		// ansi.Strip and the decoder disagree about what the escape consumed,
+		// so "visible text" itself is ill-defined. Those inputs are known
+		// pass-through GIGO; the no-panic check above still covers them.
+		if !utf8.ValidString(s) || !decodesCleanly(s) {
+			t.Skip()
+		}
+
+		// Visible text must be untouched.
+		if ansi.Strip(out) != ansi.Strip(s) {
+			t.Fatalf("visible text changed:\n in %q\nout %q", s, out)
+		}
+		// Idempotent: a second pass must be a no-op.
+		if again := isolateLineStyles(out); again != out {
+			t.Fatalf("not idempotent:\n once %q\ntwice %q", out, again)
+		}
+		// Every line self-contained: last SGR on a line that has any
+		// non-reset SGR must be a reset. Decode with the upstream parser so
+		// truncated escapes are aborted the way a terminal aborts them.
+		for i, line := range strings.Split(out, "\n") {
+			last := ""
+			var st byte
+			for len(line) > 0 {
+				seq, _, n, newState := ansi.DecodeSequenceWc(line, st, nil)
+				if n == 0 {
+					break
+				}
+				if isSGRSequence(seq) {
+					last = seq
+				}
+				line = line[n:]
+				st = newState
+			}
+			if last != "" && last != "\x1b[0m" && last != "\x1b[m" {
+				t.Fatalf("line %d leaves SGR open (%q):\n in %q\nout %q", i, last, s, out)
+			}
+		}
+	})
+}
+
+// decodesCleanly reports whether every ESC-initiated token in s is a
+// complete, well-formed escape sequence: a CSI with a final byte in
+// 0x40-0x7E and no embedded ESC, or an OSC terminated by ST or BEL.
+func decodesCleanly(s string) bool {
+	var st byte
+	for len(s) > 0 {
+		seq, _, n, newState := ansi.DecodeSequenceWc(s, st, nil)
+		if n == 0 {
+			return false
+		}
+		if seq[0] == 0x1b {
+			// A sequence whose payload spans a newline (e.g. an OSC with a
+			// literal \n inside) is bisected by the box's line splitting;
+			// no line-oriented renderer can process it. GIGO.
+			if strings.ContainsRune(seq, '\n') {
+				return false
+			}
+			switch {
+			case len(seq) >= 3 && seq[1] == '[':
+				final := seq[len(seq)-1]
+				if final < 0x40 || final > 0x7e || strings.Contains(seq[1:], "\x1b") {
+					return false
+				}
+			case len(seq) >= 2 && seq[1] == ']':
+				if !strings.HasSuffix(seq, "\x1b\\") && !strings.HasSuffix(seq, "\a") {
+					return false
+				}
+			default:
+				return false
+			}
+		}
+		s = s[n:]
+		st = newState
+	}
+	return true
+}
+
+// FuzzRender hammers the full pipeline with arbitrary title/content and a
+// bounded config. Oracles: Render never panics; on success the rendered box
+// has uniform visible row widths; rows are ANSI-self-contained for input
+// that decodes cleanly.
+func FuzzRender(f *testing.F) {
+	f.Add("Title", "hello\nworld", uint32(0))
+	f.Add("\x1b[31mR", "\x1b[32mspan\nning\x1b[0m", uint32(7))
+	f.Add("🔥", "wide 🧱\n\ttabbed", uint32(42))
+	f.Add("", "\x1b]8;;https://x\x1b\\link\x1b]8;;\x1b\\ text", uint32(99))
+	styles := []BoxStyle{Single, Double, Round, Bold, Classic, Hidden, Block}
+	positions := []TitlePosition{Inside, Top, Bottom}
+	aligns := []AlignType{Left, Center, Right}
+	colors := []string{"", "Red", "Cyan", "#00FF88"}
+	f.Fuzz(func(t *testing.T, title, content string, cfg uint32) {
+		b := NewBox().
+			Style(styles[cfg%7]).
+			TitlePosition(positions[(cfg>>3)%3]).
+			TitleAlign(aligns[(cfg>>5)%3]).
+			ContentAlign(aligns[(cfg>>7)%3]).
+			Padding(int((cfg>>9)%4), int((cfg>>11)%3)).
+			Color(colors[(cfg>>13)%4]).
+			ContentColor(colors[(cfg>>15)%4]).
+			TitleColor(colors[(cfg>>17)%4])
+		if w := (cfg >> 19) % 4; w > 0 {
+			b.WrapLimit(int(w) * 9)
+		}
+		out, err := b.Render(title, content) // must never panic
+		if err != nil {
+			return
+		}
+		if !utf8.ValidString(title) || !utf8.ValidString(content) ||
+			strings.ContainsRune(title, '\r') || strings.ContainsRune(content, '\r') ||
+			strings.ContainsRune(title, '\x1b') && !decodesCleanly(title) ||
+			strings.ContainsRune(content, '\x1b') && !decodesCleanly(content) ||
+			hasDanglingCombiningMark(title) || hasDanglingCombiningMark(content) {
+			return // GIGO input: no-panic is the only guarantee
+		}
+		rows := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+		w0 := runewidth.StringWidth(ansi.Strip(rows[0]))
+		for i, row := range rows {
+			if w := runewidth.StringWidth(ansi.Strip(row)); w != w0 {
+				t.Fatalf("row %d width %d != row 0 width %d\ntitle=%q content=%q cfg=%d\nout=%q",
+					i, w, w0, title, content, cfg, out)
+			}
+			if !rowSelfContained(row) {
+				t.Fatalf("row %d not self-contained: %q\ntitle=%q content=%q cfg=%d",
+					i, row, title, content, cfg)
+			}
+		}
+	})
+}
+
+// rowSelfContained reports whether a rendered row closes all SGR/OSC 8 state.
+func rowSelfContained(row string) bool {
+	last := ""
+	var st byte
+	for len(row) > 0 {
+		seq, _, n, newState := ansi.DecodeSequenceWc(row, st, nil)
+		if n == 0 {
+			break
+		}
+		if isSGRSequence(seq) {
+			last = seq
+		}
+		row = row[n:]
+		st = newState
+	}
+	return last == "" || last == "\x1b[0m" || last == "\x1b[m"
+}
+
+// hasDanglingCombiningMark reports whether any line's visible width is
+// context-dependent: a line starting with a bare combining mark measures
+// differently on its own than after the border/padding that the box places
+// before it (grapheme clustering attaches the mark to the preceding cell).
+// Detected semantically: prepending a space must add exactly one column.
+// Known accepted limitation, same family as U+0601.
+func hasDanglingCombiningMark(s string) bool {
+	for line := range strings.SplitSeq(ansi.Strip(s), "\n") {
+		w := runewidth.StringWidth(line)
+		if runewidth.StringWidth(" "+line) != 1+w ||
+			runewidth.StringWidth(line+" ") != w+1 {
+			return true
+		}
+	}
+	return false
+}

--- a/testdata/fuzz/FuzzIsolateLineStyles/4ec761bdacbf06cd
+++ b/testdata/fuzz/FuzzIsolateLineStyles/4ec761bdacbf06cd
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\x1b[1m\x1b\n0")

--- a/testdata/fuzz/FuzzIsolateLineStyles/9ef53e34db5ac346
+++ b/testdata/fuzz/FuzzIsolateLineStyles/9ef53e34db5ac346
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\x1b[1m\x1b[")

--- a/testdata/fuzz/FuzzIsolateLineStyles/ba1388455f6ede17
+++ b/testdata/fuzz/FuzzIsolateLineStyles/ba1388455f6ede17
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\x1b]8;;0\x1b0\n0")

--- a/testdata/fuzz/FuzzIsolateLineStyles/c0c94b15c3a8c920
+++ b/testdata/fuzz/FuzzIsolateLineStyles/c0c94b15c3a8c920
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\x1b[000000000000m0\x1b[\n0")

--- a/testdata/fuzz/FuzzRender/0f6cee7f43102ab3
+++ b/testdata/fuzz/FuzzRender/0f6cee7f43102ab3
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("\u0600")
+string("0")
+uint32(65)

--- a/testdata/fuzz/FuzzRender/1a74260528b9b165
+++ b/testdata/fuzz/FuzzRender/1a74260528b9b165
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("0")
+string("\x1b]\n\a")
+uint32(182)

--- a/testdata/fuzz/FuzzRender/2738ae113f0899f6
+++ b/testdata/fuzz/FuzzRender/2738ae113f0899f6
@@ -1,0 +1,4 @@
+go test fuzz v1
+string("0")
+string("ִ0")
+uint32(96)

--- a/types.go
+++ b/types.go
@@ -24,7 +24,12 @@ const (
 	DoubleSingle BoxStyle = "DoubleSingle"
 	// Classic is a box style using plus and minus characters.
 	Classic BoxStyle = "Classic"
-	// Hidden is a box style with invisible borders.
+	// Hidden is a box style with invisible (space) edges and visible "+"
+	// corner markers indicating the box's extent.
+	//
+	// For a fully invisible box, override the corners with spaces:
+	//
+	//	box.NewBox().Style(box.Hidden).TopLeft(" ").TopRight(" ").BottomLeft(" ").BottomRight(" ")
 	Hidden BoxStyle = "Hidden"
 	// Block is a box style with solid block characters.
 	Block BoxStyle = "Block"

--- a/util.go
+++ b/util.go
@@ -57,7 +57,7 @@ func expandTabs(s string) string {
 
 	var b strings.Builder
 	colPos := 0
-	state := byte(ansi.NormalState)
+	var state byte // zero value is ansi.NormalState
 	for len(s) > 0 {
 		seq, width, n, newState := ansi.DecodeSequenceWc(s, state, nil)
 		if n == 0 {

--- a/util.go
+++ b/util.go
@@ -47,40 +47,38 @@ func (b *Box) addVertPadding(innerWidth int) ([]string, error) {
 
 // expandTabs expands tab characters in s using tab stops at every 8 columns,
 // consistent with POSIX terminal behavior.
-// ANSI escape sequences are passed through without affecting the column count.
+// ANSI escape sequences (CSI, OSC hyperlinks and titles, and other escapes)
+// are passed through without affecting the column count; parsing is delegated
+// to ansi.DecodeSequenceWc, which returns width 0 for every sequence.
 func expandTabs(s string) string {
 	if !strings.Contains(s, "\t") {
 		return s
 	}
+
 	var b strings.Builder
 	colPos := 0
-	inEscape := false
-	for _, c := range s {
-		if c == '\033' {
-			inEscape = true
-			b.WriteRune(c)
-			continue
+	state := byte(ansi.NormalState)
+	for len(s) > 0 {
+		seq, width, n, newState := ansi.DecodeSequenceWc(s, state, nil)
+		if n == 0 {
+			// Defensive: never loop on undecodable input.
+			b.WriteString(s)
+			break
 		}
-		if inEscape {
-			b.WriteRune(c)
-			if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
-				inEscape = false
-			}
-			continue
-		}
-		switch c {
-		case '\t':
+		switch seq {
+		case "\t":
 			spaces := 8 - (colPos & 7)
 			b.WriteString(strings.Repeat(" ", spaces))
 			colPos += spaces
-		case '\n':
-			b.WriteRune(c)
+		case "\n":
+			b.WriteByte('\n')
 			colPos = 0
 		default:
-			w := max(runewidth.RuneWidth(c), 0)
-			b.WriteRune(c)
-			colPos += w
+			b.WriteString(seq)
+			colPos += width
 		}
+		s = s[n:]
+		state = newState
 	}
 	return b.String()
 }
@@ -303,13 +301,10 @@ func getConvertedColor(colorStr string) (color.Color, error) {
 	if err != nil {
 		return nil, err
 	}
-	// If profile conversion results in nil, fall back to the
-	// parsed color so we always emit color.
-	converted := profile.Convert(cv)
-	if converted == nil {
-		return cv, nil
-	}
-	return converted, nil
+	// A nil conversion means the detected color profile disables color
+	// output entirely (NO_COLOR, TERM=dumb, or a non-TTY stdout);
+	// applyConvertedColor treats nil as "no styling".
+	return profile.Convert(cv), nil
 }
 
 func applyColor(str string, colorStr string) (string, error) {
@@ -332,24 +327,43 @@ func stringColorToHex(color string) string {
 	return ""
 }
 
-// addStylePreservingOriginalFormat allows to add style around the original formating
-func addStylePreservingOriginalFormat(s string, f func(a string) string) string {
-	const reset = "\033[0m"
-	if !strings.Contains(s, reset) {
-		return f(s)
+// nextReset returns the index and byte length of the earliest SGR reset
+// sequence in s, recognizing both the long form "\x1b[0m" and the short form
+// "\x1b[m" (an omitted parameter defaults to 0). Returns -1, 0 when s
+// contains no reset.
+func nextReset(s string) (int, int) {
+	idxLong := strings.Index(s, "\033[0m")
+	idxShort := strings.Index(s, "\033[m")
+	switch {
+	case idxShort == -1:
+		return idxLong, len("\033[0m")
+	case idxLong == -1 || idxShort < idxLong:
+		return idxShort, len("\033[m")
+	default:
+		return idxLong, len("\033[0m")
 	}
+}
 
+// addStylePreservingOriginalFormat allows to add style around the original formating.
+// The string is split at every SGR reset (either spelling; see nextReset) and f is
+// applied to each segment separately, so the outer style is re-armed after any
+// reset embedded in the original string. The resets themselves are removed; f is
+// expected to terminate each styled segment with its own reset.
+func addStylePreservingOriginalFormat(s string, f func(a string) string) string {
 	var sb strings.Builder
 	start := 0
 	for {
-		idx := strings.Index(s[start:], reset)
+		idx, n := nextReset(s[start:])
 		if idx == -1 {
+			if start == 0 {
+				return f(s)
+			}
 			sb.WriteString(f(s[start:]))
 			break
 		}
 		sb.WriteString(f(s[start : start+idx]))
 		// skip the reset sequence (preserve original behavior of removing it)
-		start += idx + len(reset)
+		start += idx + n
 	}
 	return sb.String()
 }
@@ -370,7 +384,10 @@ func parseColorString(colorStr string) (color.Color, error) {
 }
 
 func applyConvertedColor(str string, c color.Color) string {
-	if c == nil {
+	// Never style an empty string: coloring "" would produce a non-empty,
+	// ANSI-only string, and callers use emptiness checks (e.g. title != "")
+	// to decide whether an element exists at all.
+	if c == nil || str == "" {
 		return str
 	}
 

--- a/util.go
+++ b/util.go
@@ -307,8 +307,9 @@ func (b *Box) buildPlainBar(left, right string, lineWidth int) string {
 // buildTitledBar builds a top or bottom bar containing a title with the given
 // alignment. Any leftover width that is not divisible by the glyph's width is
 // emitted as spaces so the fill glyph remains adjacent to the corners.
-// buildTitledBar returns the assembled bar string and the byte offset within
-// that string where plainTitle begins. The offset is -1 when title is empty.
+// buildTitledBar returns the assembled bar string and the byte offset at
+// which plainTitle begins within the ANSI-stripped form of that bar (the
+// string applyColorBar slices). The offset is -1 when title is empty.
 func (b *Box) buildTitledBar(left, right string, lineWidth int, title string, align AlignType) (string, int) {
 	fill := b.horizontal
 	leftW := charWidth(left)
@@ -343,10 +344,13 @@ func (b *Box) buildTitledBar(left, right string, lineWidth int, title string, al
 	leftSeg := buildAlignedSegment(fill, leftWidth, horizontalWidth, true)
 	rightSeg := buildAlignedSegment(fill, rightWidth, horizontalWidth, false)
 
-	// prefix contains no ANSI, so len(prefix) is the title offset in both
-	// the raw bar and the ANSI-stripped bar.
+	// The offset is consumed by applyColorBar, which slices the ANSI-stripped
+	// bar — so it must be counted in stripped bytes. The corner and fill
+	// glyphs in prefix may carry their own ANSI styling (normalizeGlyphs
+	// allows styled glyphs with visible width); counting raw bytes here would
+	// shift the offset past the title and cut multi-byte runes in half.
 	prefix := left + leftSeg + " "
-	return prefix + plainTitle + " " + rightSeg + right, len(prefix)
+	return prefix + plainTitle + " " + rightSeg + right, len(ansi.Strip(prefix))
 }
 
 // formatLine formats the line according to the information passed.

--- a/util.go
+++ b/util.go
@@ -83,6 +83,148 @@ func expandTabs(s string) string {
 	return b.String()
 }
 
+// isSGRSequence reports whether seq is an SGR (style) escape sequence:
+// CSI, numeric/;/: parameters only, final byte 'm'. Sequences with private
+// parameter markers (e.g. "\x1b[?...m") are not styles and are excluded.
+func isSGRSequence(seq string) bool {
+	if len(seq) < 3 || !strings.HasPrefix(seq, "\x1b[") || seq[len(seq)-1] != 'm' {
+		return false
+	}
+	for i := 2; i < len(seq)-1; i++ {
+		c := seq[i]
+		if (c < '0' || c > '9') && c != ';' && c != ':' {
+			return false
+		}
+	}
+	return true
+}
+
+// parseOSC8 extracts the URI from an OSC 8 hyperlink sequence
+// ("\x1b]8;params;uri" terminated by ST or BEL). An empty URI closes the
+// hyperlink. ok is false when seq is not an OSC 8 sequence, including one
+// without a proper terminator (e.g. aborted by a stray ESC): treating an
+// unterminated sequence as state would re-emit it on the next line, where it
+// swallows the text that follows it.
+func parseOSC8(seq string) (uri string, ok bool) {
+	body, found := strings.CutPrefix(seq, "\x1b]8;")
+	if !found {
+		return "", false
+	}
+	switch {
+	case strings.HasSuffix(body, "\x1b\\"):
+		body = body[:len(body)-2]
+	case strings.HasSuffix(body, "\a"):
+		body = body[:len(body)-1]
+	default:
+		return "", false
+	}
+	_, uri, found = strings.Cut(body, ";")
+	if !found {
+		return "", false
+	}
+	return uri, true
+}
+
+// styleState tracks ANSI stream state (active SGR styles and any open OSC 8
+// hyperlink) while scanning a string sequence by sequence.
+type styleState struct {
+	sgr  []string // SGR sequences active since the last reset, in order
+	link string   // open OSC 8 hyperlink sequence, "" when closed
+}
+
+// observe updates the state for one decoded sequence.
+func (st *styleState) observe(seq string) {
+	if isSGRSequence(seq) {
+		if seq == "\x1b[0m" || seq == "\x1b[m" {
+			st.sgr = st.sgr[:0]
+		} else {
+			// Replaying the sequences in order reproduces the state exactly,
+			// whatever their parameters mean individually.
+			st.sgr = append(st.sgr, seq)
+		}
+		return
+	}
+	if uri, ok := parseOSC8(seq); ok {
+		if uri == "" {
+			st.link = ""
+		} else {
+			st.link = seq
+		}
+	}
+}
+
+// writeClose emits the sequences that close all currently open state.
+func (st *styleState) writeClose(b *strings.Builder) {
+	if len(st.sgr) > 0 {
+		b.WriteString("\x1b[0m")
+	}
+	if st.link != "" {
+		b.WriteString("\x1b]8;;\x1b\\")
+	}
+}
+
+// writeReopen re-emits the sequences that restore all currently open state.
+func (st *styleState) writeReopen(b *strings.Builder) {
+	if st.link != "" {
+		b.WriteString(st.link)
+	}
+	for _, sq := range st.sgr {
+		b.WriteString(sq)
+	}
+}
+
+// isolateLineStyles makes each line of s self-contained with respect to ANSI
+// stream state. SGR styles and OSC 8 hyperlinks stay active across newlines,
+// but the box assembles every row independently, surrounding each line with
+// border glyphs and padding; state left open at a line boundary would style
+// that chrome (or make the border part of a hyperlink). Styles and hyperlinks
+// still open at the end of a line are therefore closed there and re-opened at
+// the start of the next line, preserving the author's styling across lines
+// without letting it escape into the box. State open at the end of the string
+// is closed the same way, since the final line is a box row like any other.
+func isolateLineStyles(s string) string {
+	if !strings.Contains(s, "\x1b") {
+		return s
+	}
+
+	var b strings.Builder
+	b.Grow(len(s) + 16)
+	var st styleState
+	var state byte // zero value is ansi.NormalState
+	armed := false // carried-over state was re-emitted on the current line
+	for len(s) > 0 {
+		seq, _, n, newState := ansi.DecodeSequenceWc(s, state, nil)
+		if n == 0 {
+			// Defensive: never loop on undecodable input.
+			b.WriteString(s)
+			break
+		}
+		switch seq {
+		case "\n":
+			// Only close state on lines that re-armed it: an empty line
+			// emitted nothing, so it has nothing to close.
+			if armed {
+				st.writeClose(&b)
+			}
+			b.WriteByte('\n')
+			armed = false
+		default:
+			if !armed {
+				st.writeReopen(&b)
+				armed = true
+			}
+			st.observe(seq)
+			b.WriteString(seq)
+		}
+		s = s[n:]
+		state = newState
+	}
+	if armed {
+		st.writeClose(&b)
+	}
+	return b.String()
+}
+
 // longestLine expands tabs in lines and determines longest visible
 // return longest length and array of expanded lines
 func longestLine(lines []string) (int, []expandedLine) {
@@ -349,7 +491,12 @@ func nextReset(s string) (int, int) {
 // applied to each segment separately, so the outer style is re-armed after any
 // reset embedded in the original string. The resets themselves are removed; f is
 // expected to terminate each styled segment with its own reset.
+// Empty segments — a string that is only a reset, consecutive resets, or a
+// trailing reset — are skipped entirely: styling "" would emit ANSI-only noise.
 func addStylePreservingOriginalFormat(s string, f func(a string) string) string {
+	if s == "" {
+		return s
+	}
 	var sb strings.Builder
 	start := 0
 	for {
@@ -358,10 +505,14 @@ func addStylePreservingOriginalFormat(s string, f func(a string) string) string 
 			if start == 0 {
 				return f(s)
 			}
-			sb.WriteString(f(s[start:]))
+			if seg := s[start:]; seg != "" {
+				sb.WriteString(f(seg))
+			}
 			break
 		}
-		sb.WriteString(f(s[start : start+idx]))
+		if seg := s[start : start+idx]; seg != "" {
+			sb.WriteString(f(seg))
+		}
 		// skip the reset sequence (preserve original behavior of removing it)
 		start += idx + n
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -651,3 +651,109 @@ func TestBuildTitledBar_LeftAlignedWithEmojiFill(t *testing.T) {
 		t.Errorf("expected bar to end with fill glyph, got %q", plain)
 	}
 }
+
+// TestIsolateLineStyles pins the per-line state isolation contract: SGR styles
+// and OSC 8 hyperlinks open at the end of a line are closed there and
+// re-opened on the next line, so no line depends on or leaks stream state.
+func TestIsolateLineStyles(t *testing.T) {
+	link := "\x1b]8;;https://example.com\x1b\\"
+	closeLink := "\x1b]8;;\x1b\\"
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no escapes untouched",
+			in:   "plain\ntext",
+			want: "plain\ntext",
+		},
+		{
+			name: "self-contained lines untouched",
+			in:   "\x1b[31mred\x1b[0m\n\x1b[32mgreen\x1b[0m",
+			want: "\x1b[31mred\x1b[0m\n\x1b[32mgreen\x1b[0m",
+		},
+		{
+			name: "SGR span across newline closed and re-armed",
+			in:   "\x1b[31mone\ntwo\x1b[0m tail",
+			want: "\x1b[31mone\x1b[0m\n\x1b[31mtwo\x1b[0m tail",
+		},
+		{
+			name: "unterminated SGR closed at end of string",
+			in:   "\x1b[31mred",
+			want: "\x1b[31mred\x1b[0m",
+		},
+		{
+			name: "blank line between spans stays empty",
+			in:   "\x1b[31ma\n\nb\x1b[0m",
+			want: "\x1b[31ma\x1b[0m\n\n\x1b[31mb\x1b[0m",
+		},
+		{
+			name: "stacked styles replayed in order",
+			in:   "\x1b[1m\x1b[31mbold red\nstill\x1b[0m",
+			want: "\x1b[1m\x1b[31mbold red\x1b[0m\n\x1b[1m\x1b[31mstill\x1b[0m",
+		},
+		{
+			name: "short reset recognized",
+			in:   "\x1b[31mred\x1b[m\nplain",
+			want: "\x1b[31mred\x1b[m\nplain",
+		},
+		{
+			name: "reset mid-line drops earlier state",
+			in:   "\x1b[31mred\x1b[0m\x1b[34mblue\nmore\x1b[0m",
+			want: "\x1b[31mred\x1b[0m\x1b[34mblue\x1b[0m\n\x1b[34mmore\x1b[0m",
+		},
+		{
+			name: "hyperlink span closed and re-armed",
+			in:   link + "one\ntwo" + closeLink,
+			want: link + "one" + closeLink + "\n" + link + "two" + closeLink,
+		},
+		{
+			name: "closed hyperlink not re-armed",
+			in:   link + "one" + closeLink + "\ntwo",
+			want: link + "one" + closeLink + "\ntwo",
+		},
+		{
+			name: "trailing newline leaves nothing dangling",
+			in:   "\x1b[31mred\n",
+			want: "\x1b[31mred\x1b[0m\n",
+		},
+		{
+			name: "non-SGR sequences pass through without becoming state",
+			in:   "\x1b[2Jcleared\nnext",
+			want: "\x1b[2Jcleared\nnext",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isolateLineStyles(tt.in); got != tt.want {
+				t.Errorf("isolateLineStyles(%q):\n got %q\nwant %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAddStyleSkipsEmptySegments guards against styling nothing: a string
+// that is empty, only a reset, or ends in a reset must not grow ANSI-only
+// styled-empty segments.
+func TestAddStyleSkipsEmptySegments(t *testing.T) {
+	style := func(s string) string { return "<" + s + ">" }
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"\x1b[0m", ""},
+		{"\x1b[0m\x1b[0m", ""},
+		{"hello\x1b[0m", "<hello>"},
+		{"a\x1b[0m\x1b[mb", "<a><b>"},
+	}
+	for _, tt := range tests {
+		if got := addStylePreservingOriginalFormat(tt.in, style); got != tt.want {
+			t.Errorf("addStylePreservingOriginalFormat(%q):\n got %q\nwant %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/util_test.go
+++ b/util_test.go
@@ -2,12 +2,57 @@ package box
 
 import (
 	"image/color"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/colorprofile"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
 )
+
+// TestMain pins the color profile to TrueColor: the test binary's stdout is
+// usually a pipe, which would otherwise detect as NoTTY and suppress all
+// color, making every color assertion vacuous.
+func TestMain(m *testing.M) {
+	profile = colorprofile.TrueColor
+	os.Exit(m.Run())
+}
+
+// TestApplyColorRespectsNoColorProfile guards against the old getConvertedColor
+// fallback that emitted color even when the detected profile disables it
+// (NO_COLOR, TERM=dumb, or non-TTY output).
+func TestApplyColorRespectsNoColorProfile(t *testing.T) {
+	oldProfile := profile
+	defer func() { profile = oldProfile }()
+
+	for _, p := range []colorprofile.Profile{colorprofile.NoTTY, colorprofile.Ascii} {
+		profile = p
+
+		got, err := applyColor("hello", Green)
+		if err != nil {
+			t.Fatalf("profile %v: unexpected error: %v", p, err)
+		}
+		if got != "hello" {
+			t.Errorf("profile %v: expected text unchanged, got %q", p, got)
+		}
+
+		// Invalid colors must still error even when color output is suppressed.
+		if _, err := applyColor("hello", "NotAColor"); err == nil {
+			t.Errorf("profile %v: expected error for invalid color", p)
+		}
+
+		// A fully colored Render must emit no escape sequences.
+		out, err := NewBox().Style(Single).Color(Red).TitleColor(Blue).ContentColor(Green).
+			TitlePosition(Top).Render("Title", "Content")
+		if err != nil {
+			t.Fatalf("profile %v: Render error: %v", p, err)
+		}
+		if strings.Contains(out, "\x1b[") {
+			t.Errorf("profile %v: expected no ANSI escapes in output, got %q", p, out)
+		}
+	}
+}
 
 func TestAddVertPadding(t *testing.T) {
 	b := &Box{vertical: "|"}
@@ -91,6 +136,47 @@ func TestExpandTabsWithANSI(t *testing.T) {
 	want = "Name    Age\n\033[31mAlice\033[0m   30"
 	if got != want {
 		t.Errorf("expandTabs multiline ANSI: want %q, got %q", want, got)
+	}
+}
+
+// TestExpandTabsWithOSCSequences guards against the escape tracker treating
+// every sequence like CSI ("ends at the first ASCII letter"): OSC sequences
+// exited early at the first letter of the payload (miscounting columns) and,
+// after an ESC-\ terminator, never exited — leaking raw tabs into the output.
+func TestExpandTabsWithOSCSequences(t *testing.T) {
+	// OSC-8 hyperlink, ST (ESC \) terminated: "docs" is 4 visible columns,
+	// so the tab must land the X at column 8.
+	link := "\x1b]8;;https://example.com\x1b\\docs\x1b]8;;\x1b\\"
+	got := expandTabs(link + "\tX")
+	want := link + "    X"
+	if got != want {
+		t.Errorf("OSC hyperlink tab:\n got %q\nwant %q", got, want)
+	}
+	if strings.Contains(got, "\t") {
+		t.Errorf("raw tab leaked through OSC handling: %q", got)
+	}
+
+	// BEL-terminated OSC (window-title form).
+	bel := "\x1b]0;my title\a"
+	got = expandTabs(bel + "ab\tX")
+	want = bel + "ab      X"
+	if got != want {
+		t.Errorf("BEL-terminated OSC tab:\n got %q\nwant %q", got, want)
+	}
+
+	// CSI final bytes are 0x40-0x7E, not only letters: '@' (insert character)
+	// must terminate the sequence.
+	got = expandTabs("\x1b[1@\tX")
+	want = "\x1b[1@" + strings.Repeat(" ", 8) + "X"
+	if got != want {
+		t.Errorf("CSI '@' final byte:\n got %q\nwant %q", got, want)
+	}
+
+	// Two-character escape with intermediate (ESC ( B, charset select).
+	got = expandTabs("\x1b(Bab\tX")
+	want = "\x1b(Bab      X"
+	if got != want {
+		t.Errorf("two-char escape:\n got %q\nwant %q", got, want)
 	}
 }
 
@@ -261,6 +347,62 @@ func TestAddStylePreservingOriginalFormat(t *testing.T) {
 	}
 	if got != "[foo][bar]" {
 		t.Errorf("expected styled segments [foo][bar], got %q", got)
+	}
+}
+
+// TestAddStylePreservingOriginalFormatShortReset guards against the splitter
+// recognizing only the long SGR reset "\x1b[0m": the short form "\x1b[m" —
+// which charmbracelet/x/ansi and therefore this library's own applyColor
+// emit — must be treated identically, or the outer color is lost after it.
+func TestAddStylePreservingOriginalFormatShortReset(t *testing.T) {
+	wrap := func(a string) string { return "[" + a + "]" }
+
+	if got := addStylePreservingOriginalFormat("foo\033[mbar", wrap); got != "[foo][bar]" {
+		t.Errorf("short reset not split: want [foo][bar], got %q", got)
+	}
+	if got := addStylePreservingOriginalFormat("a\033[0mb\033[mc", wrap); got != "[a][b][c]" {
+		t.Errorf("mixed resets: want [a][b][c], got %q", got)
+	}
+
+	// Both reset spellings must produce identical colored output.
+	long, err := applyColor("\x1b[31mred\x1b[0m tail", Green)
+	if err != nil {
+		t.Fatalf("applyColor error: %v", err)
+	}
+	short, err := applyColor("\x1b[31mred\x1b[m tail", Green)
+	if err != nil {
+		t.Fatalf("applyColor error: %v", err)
+	}
+	if long != short {
+		t.Errorf("reset spellings colored differently:\nlong:  %q\nshort: %q", long, short)
+	}
+}
+
+// TestApplyColorRoundTripsOwnOutput: a fragment colored by this library's own
+// applyColor (whose reset is the short "\x1b[m") embedded in content must not
+// disable ContentColor for the text that follows it.
+func TestApplyColorRoundTripsOwnOutput(t *testing.T) {
+	fragment, err := applyColor("red", Red)
+	if err != nil {
+		t.Fatalf("applyColor error: %v", err)
+	}
+	out, err := NewBox().Style(Single).ContentColor(Green).Render("", fragment+" tail")
+	if err != nil {
+		t.Fatalf("Render error: %v", err)
+	}
+	line := strings.Split(out, "\n")[1]
+
+	const green = "\x1b[38;2;0;128;0m" // Green (#008000) under the TrueColor test profile
+	idxTail := strings.Index(line, " tail")
+	if idxTail == -1 {
+		t.Fatalf("tail not found in line %q", line)
+	}
+	resetIdx := strings.LastIndex(line[:idxTail], "\x1b[m")
+	if resetIdx == -1 {
+		t.Fatalf("expected a reset before the tail in line %q", line)
+	}
+	if !strings.Contains(line[resetIdx:idxTail], green) {
+		t.Errorf("ContentColor not re-applied after the fragment's reset: %q", line)
 	}
 }
 


### PR DESCRIPTION
Fixes twelve bugs found through property sweeps (~5,600 style/position/alignment/content combinations), targeted probing, and Go native fuzzing, each verified with a reproduction before fixing.

## Fixes

| Issue | Fix |
|---|---|
| #67 | Tabs are expanded **before** wrapping, so `WrapLimit` is honored (previously exceeded by up to 7 columns per tab) |
| #68 | The detected color profile is respected: `NO_COLOR`, `TERM=dumb`, and piped/non-TTY output no longer receive escape sequences; capable terminals are unchanged |
| #69 | Top/Bottom title-bar sizing accounts for corner glyph widths, so wide corners (emoji, `++`) no longer overflow the box |
| #70 | `\r\n` is normalized to `\n` before splitting (lipgloss-style), so CRLF content no longer corrupts the box on real terminals |
| #71 | `Hidden` godoc now describes the actual v2-compatible `+` corner markers and shows how to get a fully invisible box (docs only; output unchanged) |
| #72 | The short SGR reset `\x1b[m` — emitted by x/ansi and this library itself — is treated as a cut point, so Title/Content colors survive embedded pre-colored fragments |
| #73 | Border glyphs with zero visible width (empty strings, zero-width chars, ANSI-only) are normalized to a space instead of producing ragged boxes |
| #74 | `expandTabs` delegates escape parsing to `ansi.DecodeSequenceWc`, fixing OSC-8 hyperlinks leaking raw tabs and removing the bespoke parser |
| #75 | `WrapLimit(0)` and negatives now error early with a clear message instead of silently falling back to terminal detection with contradictory advice |
| #76 | Empty strings are never styled, so an empty title with `TitleColor` no longer renders a phantom title segment/lines on color terminals |
| #78 | ANSI stream state is isolated per row: SGR spans and OSC-8 hyperlinks crossing a line boundary (via wrapping or the content's own newlines) are closed at each row end and re-opened on the next row, so they never style the borders/padding or make the chrome part of a hyperlink; with `Color`/`ContentColor` set, continuation lines now keep the user's styling instead of silently losing it |
| #81 | The titled-bar title offset is counted in stripped bytes — the string `applyColorBar` actually slices — so ANSI-styled corner/fill glyphs no longer produce a duplicated title and invalid UTF-8 (orphan `\x80` from a bisected `─`), and title coloring is no longer silently skipped with a styled fill + `TitleAlign(Right)` |

## Tests

20 new tests (32 subtests) plus two committed fuzz targets (`fuzz_test.go`) pin every fix, including a `TestMain` that pins the color profile to TrueColor so color assertions stay meaningful now that the test binary's piped stdout correctly suppresses color.

## Verification

- Full suite passes (`go test -count=1`), `go vet` clean
- 5,600-combination render sweep: all lines equal visible width, no warnings
- Custom-glyph sweep (wide/emoji/multi-char corners, verticals, horizontals × titles × alignments): 36 ragged cases before → 0 after
- Real-pty checks: `NO_COLOR=1` suppresses color, plain TTY still colors, CRLF/hyperlink/tab content renders rectangular
- #81: regression test proven to fail on the pre-fix code (reproduces the exact invalid-UTF-8 corruption); 45s targeted `FuzzRender` run (3.6M execs) clean
- #78 hard-testing: 5,292-case differential against the pre-fix build (byte-identical output for all ANSI-free input; visible text, row widths, and per-row state closure preserved for styled input); an independent terminal-emulator oracle (1,824 styled-border rows before the fix, 0 after); ~80M fuzz executions across a unit fuzzer and a render-level fuzzer; 25,600 concurrent renders of styled content on a shared Box, byte-identical and race-clean

## Behavior changes to note

- Piped output is now escape-free (previously always colored) — #68
- `WrapLimit(0)` now errors instead of silently auto-wrapping — #75
- An all-empty-glyph box renders as a space-bordered box instead of collapsed bars — #73
- Styled content spanning lines is closed and re-armed per row: borders never inherit user styles or hyperlinks, and continuation lines keep their styling even when `Color`/`ContentColor` is set — #78
- Blank lines under `ContentColor` no longer emit ANSI-only escape pairs — #78

